### PR TITLE
Recalcitrant test clean up

### DIFF
--- a/tests/data/server_requests.py
+++ b/tests/data/server_requests.py
@@ -17,7 +17,8 @@ expected = {
             "fit": 0.96835175741125701,
             "min_y_value": 0,
             "start_value": {"x": 1407117910, "y": 33.5},
-            "end_value": {"x": 1407118800, "y": 29.200000000000003}
+            "end_value": {"x": 1407118800, "y": 29.200000000000003},
+            "num_values": 90
         },
         {
             "name": "web_server_02",
@@ -25,7 +26,8 @@ expected = {
             "fit": 0.96661881091497448,
             "min_y_value": 0,
             "start_value": {"x": 1407117910, "y": 37.300000000000004},
-            "end_value": {"x": 1407118800, "y": 28.6}
+            "end_value": {"x": 1407118800, "y": 28.6},
+            "num_values": 90
         },
         {
             "name": "web_server_03",
@@ -33,7 +35,8 @@ expected = {
             "fit": 0.96496614143594028,
             "min_y_value": 0,
             "start_value": {"x": 1407117910, "y": 31.0},
-            "end_value": {"x": 1407118800, "y": 28.5}
+            "end_value": {"x": 1407118800, "y": 28.5},
+            "num_values": 90
         },
         {
             "name": "web_server_04",
@@ -41,7 +44,8 @@ expected = {
             "fit": 0.96789980416727173,
             "min_y_value": 0,
             "start_value": {"x": 1407117910, "y": 34.1},
-            "end_value": {"x": 1407118800, "y": 29.3}
+            "end_value": {"x": 1407118800, "y": 29.3},
+            "num_values": 90
         }
     ]
 }

--- a/tests/lib/compare.py
+++ b/tests/lib/compare.py
@@ -61,6 +61,7 @@ def assertParagraph(found, expected, strict=False):
     expected_sents = splitIntoSentences(expected)
 
     # Ignore whitespaces and just compare sentences
+    badly_broken = False
     for f, e in zip(found_sents, expected_sents):
         f = f.strip()
         e = e.strip()

--- a/wordgraph/analysers.py
+++ b/wordgraph/analysers.py
@@ -38,6 +38,7 @@ between consecutive points is constant.
 
 """
 
+UNPROCESSABLE = "Unprocessable"
 
 import statistics
 from scipy import stats
@@ -159,7 +160,9 @@ class NormalDistribution(FixedIntervalAnalyser):
         Sample the cumulative distribution at a number of points,
         and use that to estimate the standard deviation
         """
-        assert self.mean is not None
+        if self.mean == None:
+            # There might be only a single element
+            return 0
         result = ((self.mean - self.x_value_at(.015)) / 2 +
                   (self.mean - self.x_value_at(.16)) +
                   (self.x_value_at(.83) - self.mean) +
@@ -244,19 +247,22 @@ def get_best_analyser(values):
 
 def assert_fixed_interval(points):
     x_values = sorted(point.x for point in points)
-    if len(x_values) <= 1:
-        raise ValueError("Not enough data points!")
-    expected_interval_size = (x_values[-1] - x_values[0]) / (len(x_values) - 1)
-    for left, right in zip(x_values, x_values[1:]):
-        if abs(1 - ((right - left) / expected_interval_size)) > 0.01:
-           raise ValueError("Intervals on the X axis are not fixed width")
+    if len(x_values) < 1:
+        raise ValueError("it contains no data points!")
+    if len(x_values) == 1:
+        pass
+    else:
+        expected_interval_size = (x_values[-1] - x_values[0]) / (len(x_values) - 1)
+        for left, right in zip(x_values, x_values[1:]):
+            if abs(1 - ((right - left) / expected_interval_size)) > 0.01:
+               raise ValueError("Intervals on the X axis are not fixed width")
 
 
 def get_analysis(points):
     try:
         assert_fixed_interval(points=points)
     except ValueError as ex:
-        return dict(name="Unprocessable",
+        return dict(name=UNPROCESSABLE,
                 result=str(ex))
     y_values = [point.y for point in sorted(points)]
     analyser = get_best_analyser(points)

--- a/wordgraph/grapher.py
+++ b/wordgraph/grapher.py
@@ -77,7 +77,6 @@ class GraphiteGraph(Graph):
                 self.result_dict[key].update(raw_data[key])
 
     def as_dict(self):
-
         return self.result_dict.copy()
 
     def _create_series(self, series):
@@ -86,16 +85,25 @@ class GraphiteGraph(Graph):
         self._update_extremes(values)
         analysis = analysers.get_analysis(values)
 
-        series_dict = {
-            "name": series['target'],
-            "distribution": analysis['name'],
-            "min_y_value": analysis['min_y_value'],
-            "fit": analysis['p_value'],
-            "start_value": {"x": values[0].x, "y": values[0].y},
-            "end_value": {"x": values[-1].x, "y": values[-1].y}
-        }
+        if analysis['name'] == analysers.UNPROCESSABLE:
+            self.result_dict = analysis
+        else:
+            if len(values) == 1:
+                distribution_name = 'single-point'
+            else:
+                distribution_name = analysis['name']
 
-        self.result_dict['series'].append(series_dict)
+            series_dict = {
+                "name": series['target'],
+                "distribution": distribution_name,
+                "min_y_value": analysis['min_y_value'],
+                "fit": analysis['p_value'],
+                "start_value": {"x": values[0].x, "y": values[0].y},
+                "end_value": {"x": values[-1].x, "y": values[-1].y},
+                "num_values": len(values)
+            }
+
+            self.result_dict['series'].append(series_dict)
 
     def _update_extremes(self, values):
 

--- a/wordgraph/realiser/realiser.py
+++ b/wordgraph/realiser/realiser.py
@@ -81,13 +81,26 @@ class English(Realiser):
 
 
     """
+    def _single_data_series_with_one_point(self, data):
+        for i, item in enumerate(data['series']):
+            if item['num_values'] > 1 or i > 0:
+                return False
+        return True
+
     def long(self):
         """
         Returns the str long description using one of the
         ``templates/en/long-*.txt`` templates.
         """
         data = self._data
-        template = env.get_template("en/long/desc.txt")
+        if 'name' in data and data['name'] == "Unprocessable":
+            return "Graph invalid, because %s" % data["result"]
+        elif self._single_data_series_with_one_point(data):
+            # If there's only one series and it consists of a single point, skip the part where we explain what the range of the data is, as it's meaningless. 
+            template = env.get_template("en/long/single-point.txt")
+        else:
+            # But if there's more than one series, suddenly the range etc becomes relevant again, even if one of the series consists of a single data point.
+            template = env.get_template("en/long/desc.txt")
         return template.render(data)
 
     def short(self):
@@ -97,7 +110,12 @@ class English(Realiser):
         """
 
         data = self._data
-        template = env.get_template("en/short/desc.txt")
+        if 'name' in data and data['name'] == "Unprocessable":
+            return "Graph may be invalid, because %s" % data["result"]
+        elif self._single_data_series_with_one_point(data):
+            template = env.get_template("en/short/single-point.txt")
+        else:
+            template = env.get_template("en/short/desc.txt")
         return template.render(data)
 
 

--- a/wordgraph/realiser/templates/en/long/single-point-series.txt
+++ b/wordgraph/realiser/templates/en/long/single-point-series.txt
@@ -1,0 +1,1 @@
+The {% if data.name is defined %}{{ data.name }}{% else %}{{ series_index|num_to_word }}{% endif %} series is a single point, with value {{ y_axis.min }} at {{ x_axis.label }} {{ x_axis.min }}.

--- a/wordgraph/realiser/templates/en/long/single-point.txt
+++ b/wordgraph/realiser/templates/en/long/single-point.txt
@@ -1,0 +1,5 @@
+This graph{% if title is defined %}, {{ title }},{% endif %} shows the relationship between {{ x_axis.label }} and {{ y_axis.label }}. 
+{% for data in series %}
+    {% set series_index = loop.index %}
+    {% include "en/long/" + data['distribution']|lower + "-series.txt" %}
+{% endfor %}

--- a/wordgraph/realiser/templates/en/short/single-point-series.txt
+++ b/wordgraph/realiser/templates/en/short/single-point-series.txt
@@ -1,0 +1,1 @@
+The {% if data.name is defined %}{{ data.name }}{% else %}{{ series_index|num_to_word }}{% endif %} series is a single point with value {{ y_axis.min }} at {{ x_axis.label }} {{ x_axis.min }}.

--- a/wordgraph/realiser/templates/en/short/single-point.txt
+++ b/wordgraph/realiser/templates/en/short/single-point.txt
@@ -1,0 +1,5 @@
+This graph{% if title is defined %}, {{ title }},{% endif %} shows the relationship between {{ x_axis.label }} and {{ y_axis.label }}. 
+{% for data in series %}
+    {% set series_index = loop.index %}
+    {% include "en/long/" + data['distribution']|lower + "-series.txt" %}
+{% endfor %}


### PR DESCRIPTION
Tests for random/reverse time series restored, and now handles single data point and no data points gracefully.
